### PR TITLE
Project doesn't build with this function

### DIFF
--- a/TCS34725AutoGain.h
+++ b/TCS34725AutoGain.h
@@ -196,10 +196,6 @@ public:
 
     void persistence(uint8_t data) { write8(Reg::PERS, data); }
 
-    uint8_t persistence() {
-        read8(Reg::PERS, data);
-    }
-
     bool available()
     {
         bool b = interrupted();


### PR DESCRIPTION
I wanted to contact you via your contact form at https://kevinstadler.github.io/contact/ but that returns a 405.

The library currently doesn't build, since `data` isn't declared in the `uint8_t persistence()` function.. 

The culprit seems to be:

    uint8_t persistence() {
        read8(Reg::PERS, data);
    }

And the error being
.pio\libdeps\d1_mini-ColorSensor\TCS34725AutoGain/TCS34725AutoGain.h: In member function 'uint8_t TCS34725_<WireType>::persistence()':  
.pio\libdeps\d1_mini-ColorSensor\TCS34725AutoGain/TCS34725AutoGain.h:200:26: error: 'data' was not declared in this scope; did you mean 'std::data'?

The persistence function seems to be introduced here: https://github.com/kevinstadler/TCS34725AutoGain/commit/6ff03e49a21bbd0b0d14d5fc7f1d59969e8d39dc and not used anywhere in the library. I don't know whether I am doing something wrong, sorry for misusing this PR as a means of communication. The library works for me without that persistence function.